### PR TITLE
Add suppport for file sent on stdin.

### DIFF
--- a/Yii/Sniffs/Files/Utf8EncodingSniff.php
+++ b/Yii/Sniffs/Files/Utf8EncodingSniff.php
@@ -63,9 +63,14 @@ class Yii_Sniffs_Files_Utf8EncodingSniff implements PHP_CodeSniffer_Sniff
 				return;
 		}
 
-		$filePath    = $phpcsFile->getFilename();
-		$fileContent = file_get_contents($filePath);
-		$encoding    = mb_detect_encoding($fileContent, 'UTF-8, ASCII, ISO-8859-1');
+		$filePath = $phpcsFile->getFilename();
+		if ($filePath === 'STDIN') {
+			$fileContent = file_get_contents('php://stdin');
+		} else {
+			$fileContent = file_get_contents($filePath);
+		}
+
+		$encoding = mb_detect_encoding($fileContent, 'UTF-8, ASCII, ISO-8859-1');
 
 		if ($encoding !== 'UTF-8') {
 			$fileName = basename($filePath);


### PR DESCRIPTION
There is an issue when calling this ruleset via arc lint that causes it to fail with the following error message: 

``` Exception
Some linters failed:
    - ArcanistPhpcsLinter: CommandException: Command failed with error #1!
      COMMAND
      'phpcs' '--report=xml' '--standard=Yii'

      STDOUT

      Warning: file_get_contents(STDIN): failed to open stream: No such file or directory in /Volumes/src/copper/build/coding_standards/Yii/Sniffs/Files/Utf8EncodingSniff.php on line 67
      <?xml version="1.0" encoding="UTF-8"?>
      <phpcs version="2.0.0">
      <file name="STDIN" errors="4" warnings="0" fixable="4">
       <error line="4" column="5" source="Squiz.WhiteSpace.OperatorSpacing.NoSpaceBefore" severity="5" fixable="1">Expected 1 space before &quot;=&quot;; 0 found</error>
       <error line="4" column="5" source="Squiz.WhiteSpace.OperatorSpacing.NoSpaceAfter" severity="5" fixable="1">Expected 1 space after &quot;=&quot;; 0 found</error>
       <error line="5" column="8" source="Squiz.WhiteSpace.OperatorSpacing.NoSpaceBefore" severity="5" fixable="1">Expected 1 space before &quot;=&quot;; 0 found</error>
       <error line="5" column="8" source="Squiz.WhiteSpace.OperatorSpacing.NoSpaceAfter" severity="5" fixable="1">Expected 1 space after &quot;=&quot;; 0 found</error>
      </file>
      </phpcs>


      STDERR
      PHP Warning:  file_get_contents(STDIN): failed to open stream: No such file or directory in /Volumes/src/copper/build/coding_standards/Yii/Sniffs/Files/Utf8EncodingSniff.php on line 67
```

Basically, arcanist sends the data to phpcs on stdin, and then this rule isn't able to deal with it because it can't open the file STDIN.  

This pull request checks to see if the filename is STDIN, and if so, uses php://stdin for the call to file_get_contents()  

Also tested with an actual file named STDIN, and the code still works as expected. 
