### PR TITLE
Eliminating do-while false positives from SingleLineWithoutBracesSniff

### DIFF
--- a/Yii/Sniffs/ControlStructures/SingleLineWithoutBracesSniff.php
+++ b/Yii/Sniffs/ControlStructures/SingleLineWithoutBracesSniff.php
@@ -125,6 +125,17 @@ class Yii_Sniffs_ControlStructures_SingleLineWithoutBracesSniff implements PHP_C
 				$n++;
 			}
 			
+			if ($tokens[$closeBracket + $n]['type'] == 'T_SEMICOLON' && $tokens[$stackPtr]['code'] == T_WHILE) {
+				$p = 1;
+				while ($tokens[$stackPtr - $p]['type'] == 'T_WHITESPACE') {
+					$p++;
+				}
+				if ($tokens[$stackPtr - $p]['code'] == T_CLOSE_CURLY_BRACKET
+				&& $tokens[$tokens[$stackPtr - $p]['scope_condition']]['code'] == T_DO) {
+					return; // a do-while structure, should be ignored
+				}
+			}
+
 			if ($newline === false) {
 				$error = 'Single line "%s" must have an expression started from new line. ';
 				$phpcsFile->addError($error, $stackPtr, 'SingleLineExpressionMustHaveANewLineExpression', array(strtoupper($tokens[$stackPtr]['content'])));

--- a/Yii/Sniffs/ControlStructures/SingleLineWithoutBracesSniff.php
+++ b/Yii/Sniffs/ControlStructures/SingleLineWithoutBracesSniff.php
@@ -125,14 +125,15 @@ class Yii_Sniffs_ControlStructures_SingleLineWithoutBracesSniff implements PHP_C
 				$n++;
 			}
 			
+			// next token is a semicolon and we're looking at a while() structure - chances are it's a do-while
 			if ($tokens[$closeBracket + $n]['type'] == 'T_SEMICOLON' && $tokens[$stackPtr]['code'] == T_WHILE) {
 				$p = 1;
-				while ($tokens[$stackPtr - $p]['type'] == 'T_WHITESPACE') {
+				while ($tokens[$stackPtr - $p]['type'] == 'T_WHITESPACE') { // check for previous token
 					$p++;
 				}
 				if ($tokens[$stackPtr - $p]['code'] == T_CLOSE_CURLY_BRACKET
 				&& $tokens[$tokens[$stackPtr - $p]['scope_condition']]['code'] == T_DO) {
-					return; // a do-while structure, should be ignored
+					return; // a do-while structure with explicit do {} block, should be ignored
 				}
 			}
 

--- a/Yii/Sniffs/ControlStructures/SingleLineWithoutBracesSniff.php
+++ b/Yii/Sniffs/ControlStructures/SingleLineWithoutBracesSniff.php
@@ -135,6 +135,17 @@ class Yii_Sniffs_ControlStructures_SingleLineWithoutBracesSniff implements PHP_C
 				&& $tokens[$tokens[$stackPtr - $p]['scope_condition']]['code'] == T_DO) {
 					return; // a do-while structure with explicit do {} block, should be ignored
 				}
+				if ($tokens[$stackPtr - $p]['code'] == T_SEMICOLON) {
+					// a statement precedes the while() structure, may be single line do block
+					// check for the previous semicolon or 'do' keyword, whichever comes first
+					$p++;
+					while (!in_array($tokens[$stackPtr - $p]['code'], array(T_SEMICOLON, T_DO))) {
+						$p++;
+					}
+					if ($tokens[$stackPtr - $p]['code'] == T_DO) {
+						return; // it's a single statement do block
+					}
+				}
 			}
 
 			if ($newline === false) {


### PR DESCRIPTION
Hi,

SingleLineWithoutBracesSniff generates a false positive on every do-while structure. (Ironically, SingleLineWithoutBracesSniff class file contains such structure, so can be used to reproduce the issue.)

This is due to registering to the T_WHILE token without checking if it's the end of a `do {} while();` or a beginning of a `while() {}` block.

The following patch checks for exactly that: it detects whether the next token (as traversed by the existing code looking for a newline) is a semicolon and whether previous non-whitespace token meets one of the following conditions:
- is a closing curly brace belonging to a `do {}` block
- is a semicolon, ending a statement which is an implicit, single-statement `do` block (i.e. `do` keyword is observed before another semicolon when traversing further backwards)
